### PR TITLE
Added community, learning, and TODO list pages

### DIFF
--- a/src/pages/wiki/community/index.mdx
+++ b/src/pages/wiki/community/index.mdx
@@ -1,0 +1,15 @@
+# Bitwig Studio Community
+
+Below are some of the Bitwig Studio community resources available online:
+
+- [Bitwig Q&A][1]
+- [Bitwig Studio Community][2]
+- [Bitwig Discord chat][3]
+- [KVR Forums / Bitwig][4]
+- [r/Bitwig][5]
+
+[1]: https://answers.bitwig.com/
+[2]: https://bitwig.community/
+[3]: https://discord.gg/0g2ZPafIN3eWParf
+[4]: https://www.kvraudio.com/forum/viewforum.php?f=259
+[5]: https://www.reddit.com/r/Bitwig/

--- a/src/pages/wiki/index.mdx
+++ b/src/pages/wiki/index.mdx
@@ -2,9 +2,11 @@
 
 # Welcome to BitWiki 🐱‍🏍 the Bitwig Studio Wiki 
 
-Welcome to the first comprehensive Bitwig Wiki. It is mainly maintained by the community and does not claim to be complete. Here you should find all information about Bitwig. Little tips and tricks or big guides and tutorials.
+Welcome to the first comprehensive Bitwig Wiki. It is mainly maintained by the community
+and does not claim to be complete. Here you should find all information about Bitwig.
+Little tips and tricks or big guides and tutorials.
 
-
+* [Community](community) - list of Bitwig community resources
 * [Tips & Tricks](tips-tricks) - some small things you probably missed
 * [Frequently Asked Questions](faq) - all the answers to usual questions
 
@@ -12,10 +14,15 @@ Welcome to the first comprehensive Bitwig Wiki. It is mainly maintained by the c
 
 ## How can I participate?
 
-The pages are located on [github.com][1] and can be changed there either directly (you need a repository membership) or you fork the repo and start a pull request (after a short check the pull request will be accepted or rejected).
+The pages are located on [github.com][1] and can be changed there either directly (you
+need a repository membership) or you fork the repo and start a pull request (after a
+short check the pull request will be accepted or rejected).
 
 ### Where are all the Files?
-The wiki pages are all located in the subdirectory `src/pages/wiki` and can easily be filled with [markdown][3] (use .mdx for new files). After every change, the website will be regenerated and published on [bitwig.community/wiki][2]
+
+The wiki pages are all located in the subdirectory `src/pages/wiki` and can easily be
+filled with [markdown][3] (use .mdx for new files). After every change, the website will
+be regenerated and published on [bitwig.community/wiki][2]
 
 [1]: https://github.com/polarity/bitwig.community
 [2]: https://bitwig.community/wiki/

--- a/src/pages/wiki/index.mdx
+++ b/src/pages/wiki/index.mdx
@@ -7,6 +7,7 @@ and does not claim to be complete. Here you should find all information about Bi
 Little tips and tricks or big guides and tutorials.
 
 * [Community](community) - list of Bitwig community resources
+* [Learning](learning) - resources for learning Bitwig Studio
 * [Tips & Tricks](tips-tricks) - some small things you probably missed
 * [Frequently Asked Questions](faq) - all the answers to usual questions
 
@@ -17,6 +18,8 @@ Little tips and tricks or big guides and tutorials.
 The pages are located on [github.com][1] and can be changed there either directly (you
 need a repository membership) or you fork the repo and start a pull request (after a
 short check the pull request will be accepted or rejected).
+
+* [TODO list](todo)
 
 ### Where are all the Files?
 

--- a/src/pages/wiki/learning/index.mdx
+++ b/src/pages/wiki/learning/index.mdx
@@ -1,0 +1,25 @@
+# Learning Bitwig Studio
+
+Below are some resources for learning Bitwig Studio.
+
+## Documentation
+
+- [Bitwig Studio manual](https://dash.bitwig.com/documentation/Bitwig%20Studio%20User%20Guide%20English.pdf)
+
+## Courses
+
+- [Ask.Video](https://ask.video/library/application/bitwigstudio?afid=bUM6RfN2U6)
+- [Sonic Academy](https://www.sonicacademy.com/courses/introduction-to-bitwig-studio)
+
+## Tutorials
+
+### Youtube
+
+Some useful Youtube accounts to check out:
+
+- [Baphometrix](https://www.youtube.com/channel/UCuzDmHD4WeS4dwhFXPgm7GA)
+- [bitwig](https://www.youtube.com/user/bitwig)
+- [Mattias Holmgren](https://www.youtube.com/channel/UCPI1x2iyASeNaeRYVSGXTqA)
+- [Polarity Music](https://www.youtube.com/user/polaritydnb)
+- [TÂCHES](https://www.youtube.com/watch?v=nbEeaV0TgTI&list=PLn_168CDEmDfrzQwHI6_LSvXfdyGC2kLm)
+

--- a/src/pages/wiki/todo/index.mdx
+++ b/src/pages/wiki/todo/index.mdx
@@ -1,0 +1,45 @@
+# TODO List
+
+List of topics to potentially be included on the Wiki...
+
+## Meta
+
+- comparison to other daws
+  - ableton
+  - flstudio
+  - could be useful to create a summary table / "cheat sheet" with the major differences
+    between each of of the major daws.
+- getting help
+- bitwig-specific features
+- missing features
+- producers using bitwig
+
+## Bitwig
+
+One possible way to organize the main bitwig wiki pages would be to follow the
+organization of the manual..
+
+When creating topic-specific pages such as those below, one could consider linking to
+relevant Youtube tutorials to make it easy for users to find more information on each
+topic.
+
+- audio
+  - audio clips/events
+  - bouncing
+  - recording
+- instruments
+  - polysynth
+  - fm4
+- effects
+  - each effect could have its own page with an overview + tips & tricks / recipes / etc.
+  - another useful effects-related page could be an (opinionated) overview of which
+    bitwig stock effects are good on their own, and which ones are not-so-great, for
+    which users may want to look to third-party vsts.
+- automation
+- midi
+- modulation
+- grid
+- keyboard shortcuts
+- settings
+- ui
+- templates


### PR DESCRIPTION
Greetings!

I started putting together a few pages that I think would be useful to include on the Wiki.

One of the pages is simply a "TODO" list where you/others can list potential topics to be added to the Wiki. In addition to keeping track of what is missing, this could also be helpful to give users of topics they could contribute on.

On a related note, do you have any preference for Markdown style? If so, perhaps you could link to a style guide in the "contributing" section, or create a separate "contributing" page with the style guidelines.

Cheers,
Keith